### PR TITLE
Creating an Iris-dedicated section of the Docs

### DIFF
--- a/docs/iris/README.md
+++ b/docs/iris/README.md
@@ -1,0 +1,39 @@
+---
+displayed_sidebar: softwareIris
+description: >
+    Iris is the at-home hospice management system developed by the Ojos Project.
+    It is free and fully open-source. Made with love at the University of
+    California, Irvine.
+last_update:
+    author: Carlos Valdez
+    date: April 28 2024
+---
+# Iris Docs
+
+![Ojos Project header](@site/static/images/header.png)
+
+## Table of Contents
+
+- [Iris Docs](#iris-docs)
+  - [Table of Contents](#table-of-contents)
+  - [Introduction](#introduction)
+  - [Who these docs are for](#who-these-docs-are-for)
+
+## Introduction
+
+Iris is the at-home hospice management system developed by the Ojos Project.
+This documentation provides extensive details about the software requirements,
+design, and code for the Iris software. It is developed by the [Ojos Project
+Developers team](/docs/url/developers/).
+
+Ready to dig in? Get started at the
+[Iris repository](https://github.com/ojosproject/iris/).
+
+Made with 💙💛 at UCI.
+
+## Who these docs are for
+
+The Iris Docs are for people wanting to get a deeper understanding of the Iris
+software's inner workings. A lot of different things will be made available,
+whether it's documenting the installation process, troubleshooting, the code,
+showcasing success stories, etc.

--- a/docs/iris/README.md
+++ b/docs/iris/README.md
@@ -12,13 +12,6 @@ last_update:
 
 ![Ojos Project header](@site/static/images/header.png)
 
-## Table of Contents
-
-- [Iris Docs](#iris-docs)
-  - [Table of Contents](#table-of-contents)
-  - [Introduction](#introduction)
-  - [Who these docs are for](#who-these-docs-are-for)
-
 ## Introduction
 
 Iris is the at-home hospice management system developed by the Ojos Project.

--- a/docs/iris/c4-model.mdx
+++ b/docs/iris/c4-model.mdx
@@ -1,5 +1,5 @@
 ---
-displayed_sidebar: groupUrl
+displayed_sidebar: softwareIris
 description: >
     View the C4 Model by the URL Group Developers team.
 last_update:

--- a/docs/iris/database-schema.mdx
+++ b/docs/iris/database-schema.mdx
@@ -1,5 +1,5 @@
 ---
-displayed_sidebar: groupUrl
+displayed_sidebar: softwareIris
 description: >
     View the database schema designed by the Developers team. This is how the
     Iris database will work.

--- a/docs/iris/flowcharts.mdx
+++ b/docs/iris/flowcharts.mdx
@@ -1,5 +1,5 @@
 ---
-displayed_sidebar: groupUrl
+displayed_sidebar: softwareIris
 description: >
     View the flowcharts designed by the Developers team for the Iris system.
 last_update:

--- a/docs/iris/requirements.mdx
+++ b/docs/iris/requirements.mdx
@@ -1,4 +1,5 @@
 ---
+displayed_sidebar: softwareIris
 description: >
     View iterations of the Iris requirements document.
 last_update:

--- a/docs/url/developers/README.md
+++ b/docs/url/developers/README.md
@@ -10,8 +10,8 @@ last_update:
 
 # Developers Team
 
-The Developers team of the Ojos Project is in charge of building the software
-infrastructure of the device and the organization as a whole.
+The Developers team of the Ojos Project is in charge of building Iris, the
+at-home hospice management system.
 
 ## Responsibilities
 

--- a/docs/url/developers/README.md
+++ b/docs/url/developers/README.md
@@ -39,7 +39,7 @@ the tools we use are:
 | Tool           | Setup                                      | Reason                                              |
 | -------------- | ------------------------------------------ | --------------------------------------------------- |
 | macOS or Linux | N/A                                        | Ensuring we can use the same bash scripts.          |
-| Gaphor         | [gaphor.org](https://gaphor.org/download/) | [C4 Model design](/docs/url/developers/c4-model/) |
+| Gaphor         | [gaphor.org](https://gaphor.org/download/) | [C4 Model design](/docs/iris/c4-model/) |
 
 ## Resources
 

--- a/docs/url/meeting-reports.md
+++ b/docs/url/meeting-reports.md
@@ -45,7 +45,7 @@ Enter what this team did during the meeting!
 ### Developers
 
 Developers decided to work on the
-[Iris database scheme](/docs/url/developers/database-schema/) since working on
+[Iris database scheme](/docs/iris/database-schema/) since working on
 class diagrams became complicated without having a solid idea of what exactly
 the database will have. The database schema is mostly finalized.
 
@@ -57,7 +57,7 @@ Ayush and Jason worked on creating a dummy database to see how effective our
 schema is.
 
 Carlos and Jesse worked on a
-[flowchart diagram for the Symposium](/docs/url/developers/flowcharts).
+[flowchart diagram for the Symposium](/docs/iris/flowcharts).
 
 ## April 25, 2024
 
@@ -119,7 +119,7 @@ This report is still in progress.
 
 The Developers worked on the C4 Model more, creating a rough draft of the
 Container Diagram and the Component Diagram, both of which will be found in the
-[C4 Model page](/docs/url/developers/c4-model).
+[C4 Model page](/docs/iris/c4-model).
 
 The Developers have also agreed to develop a mobile app for Iris written in
 [React Native](https://reactnative.dev/) to keep only one extra codebase. This

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -64,7 +64,12 @@ const config: Config = {
       redirects: [
         {from: '/join-us/', to: '/news/join-us/'},
         {from: '/qr/', to: '/'}, // Old `/qr/`
-        {from: '/iris/', to: '/docs/iris/'}
+        {from: '/iris/', to: '/docs/iris/'},
+        {from: '/docs/url/requirements/', to: '/docs/iris/requirements/'},
+        {from: '/docs/url/developers/design/', to: '/docs/iris/design/'},
+        {from: '/docs/url/developers/c4-model/', to: '/docs/iris/c4-model/'},
+        {from: '/docs/url/developers/database-schema/', to: '/docs/iris/database-schema/'},
+        {from: '/docs/url/developers/flowcharts/', to: '/docs/iris/flowcharts/'}
       ]
     }
   ]],

--- a/docusaurus.config.ts
+++ b/docusaurus.config.ts
@@ -63,7 +63,8 @@ const config: Config = {
     {
       redirects: [
         {from: '/join-us/', to: '/news/join-us/'},
-        {from: '/qr/', to: '/'} // Old `/qr/`
+        {from: '/qr/', to: '/'}, // Old `/qr/`
+        {from: '/iris/', to: '/docs/iris/'}
       ]
     }
   ]],

--- a/news/2024/03-19-winter-2024-wrap.md
+++ b/news/2024/03-19-winter-2024-wrap.md
@@ -33,7 +33,7 @@ are building the right thing with the information we've gotten from the
 interviews and our research.
 
 Since our requirements aren't yet ready, it isn't published. Once it is though,
-[you can find them here](/docs/url/requirements/).
+[you can find them here](/docs/iris/requirements/).
 
 ### Hardware
 

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -29,7 +29,21 @@ const sidebars: SidebarsConfig = {
       link: {type: 'doc', id: 'iris/README'},
       label: 'Iris Docs',
       collapsible: false,
-      items: ['url/developers/README', 'iris/README']
+      items: ['url/developers/README',
+      {
+        type: 'category',
+        link: {
+          type: 'generated-index',
+          title: 'Software Design',
+          description: 'These are designs made by the Developers team. They\'re often made with Figma.',
+          slug: 'iris/design/',
+          image: '@site/static/images/uci-pride-header.png'
+        },
+        label: 'Design',
+        collapsible: true,
+        items: ['iris/c4-model', 'iris/database-schema', 'iris/flowcharts']
+      }
+      ]
     }
   ],
 
@@ -47,19 +61,6 @@ const sidebars: SidebarsConfig = {
           label: 'Developers',
           collapsible: true,
           items: [
-            {
-              type: 'category',
-              link: {
-                type: 'generated-index',
-                title: 'Software Design',
-                description: 'These are designs made by the Developers team. They\'re often made with Figma.',
-                slug: 'url/developers/design/',
-                image: '@site/static/images/uci-pride-header.png'
-              },
-              label: 'Design',
-              collapsible: true,
-              items: ['url/developers/c4-model', 'url/developers/database-schema', 'url/developers/flowcharts']
-            },
             {
               type: 'category',
               label: 'Guides',

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -23,6 +23,16 @@ const sidebars: SidebarsConfig = {
     },
   ],
 
+  softwareIris: [
+    {
+      type: 'category',
+      link: {type: 'doc', id: 'iris/README'},
+      label: 'Iris Docs',
+      collapsible: false,
+      items: ['url/developers/README', 'iris/README']
+    }
+  ],
+
   groupUrl: [
     {
       type: 'category',


### PR DESCRIPTION
# Summary

This Pull Request makes a new path, `/docs/iris/`, which moves a few things from `/docs/url/developers/` to the new path. This includes:

- Iris Requirements
- Iris Software Design

This also would mean having to make redirects for the above pages.

This PR also includes a new sidebar for the Iris side of the docs, a few updates to the Developers side of the docs, and redirecting `/iris/` to `/docs/iris/`. We will eventually use `/iris/` to promote it, but for now, it redirects to the docs.

## Tasks

- [x] Move Iris Requirements
- [x] Move Iris Software Design
  - [x] C4 Model
  - [x] Database Schema
  - [x] Flowchart
- [x] Redirect all of the above movements
- [x] Fix broken links in `/docs/` and `/news/`
- [ ] Add mentions of Iris to `/docs/url/developers/`