### PR TITLE
Added documentation for Kimai, the timesheet app

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -12,6 +12,7 @@
 		"IN4MATX",
 		"incómod",
 		"irvine",
+		"kimai",
 		"LAEP",
 		"Luong",
 		"LXDE",
@@ -37,6 +38,7 @@
 		"Telehealth",
 		"telemedicine",
 		"Telemedicine",
+		"timesheet",
 		"UROP",
 		"xinitrc"
 	],

--- a/docs/website/kimai.md
+++ b/docs/website/kimai.md
@@ -1,0 +1,22 @@
+---
+displayed_sidebar: softwareWebsite
+description: >
+  Kimai is the software the Ojos Project is going to use to track attendance and
+  time logging for LAEP funding.
+last_update:
+  date: June 17, 2024
+  author: Carlos Valdez
+---
+# Kimai: Time Logging and Attendance
+
+In order to better keep track of attendance and time logging for Summer 2024,
+Ojos Project is going to be using [Kimai](https://github.com/kimai/kimai/).
+Kimai is a free and open-source time logger. We will be using this software to
+log our hours at the project.
+
+## Logging In
+
+To log into Kimai, you must go to
+[timesheet.ojosproject.org](timesheet.ojosproject.org). **Your login username
+will be your UCINetID.** That is, the part before `@uci.edu` in your emails. The
+program will prompt you to change your password.

--- a/sidebars.ts
+++ b/sidebars.ts
@@ -117,6 +117,7 @@ const sidebars: SidebarsConfig = {
 			collapsible: false,
 			items: [
 				"website/gravatar",
+				"website/kimai",
 				"website/members-json",
 				"website/updating-docs",
 				"website/updating-meeting-reports",


### PR DESCRIPTION
Ojos Project will be using [Kimai](https://github.com/kimai/kimai/), the time logging app for LAEP/attendance purposes. As I'm installing this, I'm also writing documentation so that people can learn how to use it.